### PR TITLE
fix: harden JSON responses, config handling, and install build flow

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
+set -euo pipefail
+
 burp_ext_root='/opt/pwn_burp'
+java_home='/usr/lib/jvm/java-21-openjdk-amd64'
 gradle_cache_dir="${burp_ext_root}/.gradle"
 build_root="$burp_ext_root/build"
 build_libs="$build_root/libs"
 pwn_burp_backup="${burp_ext_root}.BAK"
-swagger_ui_root="${burp_ext_root}/src/main/resources/swagger-ui"
 burp_root='/opt/burpsuite'
+
+# Pin Gradle runtime to Java 21 for this repo so future system Java changes
+# (e.g. newer EA releases) do not break the build.
+export JAVA_HOME="${java_home}"
+export PATH="${JAVA_HOME}/bin:${PATH}"
+
+cd "$burp_ext_root"
+
+# If install.sh is run with sudo, build as the original user to avoid root-owned
+# Gradle/build artifacts that later break non-sudo development commands.
+if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+  BUILD_CMD=(sudo -u "${SUDO_USER}" env JAVA_HOME="${JAVA_HOME}" PATH="${PATH}" ./gradlew)
+else
+  BUILD_CMD=(./gradlew)
+fi
 
 if [[ -d "${gradle_cache_dir}" ]]; then
   echo "Stopping Gradle Daemon..."
-  ./gradlew --stop
+  "${BUILD_CMD[@]}" --stop || true
 fi
 
 if [[ ! -d "${burp_root}" ]]; then
@@ -18,9 +35,12 @@ if [[ ! -d "${burp_root}" ]]; then
 fi
 
 # Build the project
-cd "$burp_ext_root" && \
-  ./gradlew clean build shadowJar && \
-  tree . > STRUCTURE.txt && \
-  sudo cp ${build_libs}/pwn-burp.jar $burp_root/pwn-burp.jar && \
-  if [[ -d "${pwn_burp_backup}" ]]; then sudo rm -rf "${pwn_burp_backup}"; fi && \
-  sudo cp -a "${burp_ext_root}" "${pwn_burp_backup}"
+"${BUILD_CMD[@]}" clean build shadowJar
+
+tree . > STRUCTURE.txt
+sudo cp "${build_libs}/pwn-burp.jar" "$burp_root/pwn-burp.jar"
+
+if [[ -d "${pwn_burp_backup}" ]]; then
+  sudo rm -rf "${pwn_burp_backup}"
+fi
+sudo cp -a "${burp_ext_root}" "${pwn_burp_backup}"

--- a/src/main/java/com/pwn_burp/api/handlers/ProxyHandler.java
+++ b/src/main/java/com/pwn_burp/api/handlers/ProxyHandler.java
@@ -91,7 +91,7 @@ public class ProxyHandler {
         String highlight = ctx.queryParamAsClass("highlight", String.class).getOrDefault("NONE");
 
         ctx.status(200);
-        ctx.json(pwnService.getProxyHistory(urlPrefix, limit, offset, highlight));
+        respondWithJsonString(ctx, pwnService.getProxyHistory(urlPrefix, limit, offset, highlight));
     }
 
     @OpenApi(
@@ -149,13 +149,22 @@ public class ProxyHandler {
         }
     )
     private void getProxyHistoryByUrl(Context ctx) {
-        String urlPrefix = new String(Base64.getDecoder().decode(ctx.pathParam("url") != null ? ctx.pathParam("url") : ""));
+        String encodedUrl = ctx.pathParam("url") != null ? ctx.pathParam("url") : "";
+        String urlPrefix;
+        try {
+            urlPrefix = new String(Base64.getDecoder().decode(encodedUrl));
+        } catch (IllegalArgumentException e) {
+            ctx.status(400);
+            ctx.json(pwnService.apiError("url", "Invalid Base64-encoded URL prefix"));
+            return;
+        }
+
         int limit  = ctx.queryParamAsClass("limit", Integer.class).getOrDefault(200);
         int offset = ctx.queryParamAsClass("offset", Integer.class).getOrDefault(0);
         String highlight = ctx.queryParamAsClass("highlight", String.class).getOrDefault("NONE");
 
         ctx.status(200);
-        ctx.json(pwnService.getProxyHistory(urlPrefix, limit, offset, highlight));
+        respondWithJsonString(ctx, pwnService.getProxyHistory(urlPrefix, limit, offset, highlight));
     }
 
     @OpenApi(
@@ -215,7 +224,7 @@ public class ProxyHandler {
         String highlight = ctx.queryParamAsClass("highlight", String.class).getOrDefault("NONE");
 
         ctx.status(200);
-        ctx.json(pwnService.getWebSocketHistory(urlPrefix, limit, offset, highlight));
+        respondWithJsonString(ctx, pwnService.getWebSocketHistory(urlPrefix, limit, offset, highlight));
     }
 
     @OpenApi(
@@ -395,5 +404,10 @@ public class ProxyHandler {
           ctx.status(404);
           ctx.json(pwnService.apiError("listener", "Proxy listener not found or deletion unsupported in Montoya API"));
       }
+    }
+
+    private void respondWithJsonString(Context ctx, String json) {
+        ctx.contentType("application/json");
+        ctx.result(json == null ? "{}" : json);
     }
 }

--- a/src/main/java/com/pwn_burp/api/handlers/ScanHandler.java
+++ b/src/main/java/com/pwn_burp/api/handlers/ScanHandler.java
@@ -58,7 +58,16 @@ public class ScanHandler {
         }
     )
     private void getScanIssuesByUrl(Context ctx) {
-        String url = new String(Base64.getDecoder().decode(ctx.pathParam("url") != null ? ctx.pathParam("url") : ""));
+        String encodedUrl = ctx.pathParam("url") != null ? ctx.pathParam("url") : "";
+        String url;
+        try {
+            url = new String(Base64.getDecoder().decode(encodedUrl));
+        } catch (IllegalArgumentException e) {
+            ctx.status(400);
+            ctx.json(pwnService.apiError("url", "Invalid Base64-encoded URL"));
+            return;
+        }
+
         ctx.status(200);
         ctx.json(pwnService.scanIssuesToJsonArray(pwnService.getScanIssues(url)));
     }
@@ -125,7 +134,7 @@ public class ScanHandler {
     )
     private void getActiveScanStatus(Context ctx) {
         ctx.status(200);
-        ctx.json(pwnService.getActiveScanStatus());
+        respondWithJsonString(ctx, pwnService.getActiveScanStatus());
     }
 
     @OpenApi(
@@ -148,7 +157,7 @@ public class ScanHandler {
                 ctx.json(pwnService.apiError("id", "scan item not found"));
             } else {
                 ctx.status(200);
-                ctx.json(result);
+                respondWithJsonString(ctx, result);
             }
         } catch (NumberFormatException e) {
             ctx.status(400);
@@ -342,7 +351,7 @@ public class ScanHandler {
     )
     private void getSpiderStatus(Context ctx) {
         ctx.status(200);
-        ctx.json(pwnService.getCrawlStatus());
+        respondWithJsonString(ctx, pwnService.getCrawlStatus());
     }
 
     @OpenApi(
@@ -365,7 +374,7 @@ public class ScanHandler {
                 ctx.json(pwnService.apiError("id", "spider item not found"));
             } else {
                 ctx.status(200);
-                ctx.json(result);
+                respondWithJsonString(ctx, result);
             }
         } catch (NumberFormatException e) {
             ctx.status(400);
@@ -403,5 +412,10 @@ public class ScanHandler {
             ctx.status(400);
             ctx.json(pwnService.apiError("id", "Invalid spider ID format"));
         }
+    }
+
+    private void respondWithJsonString(Context ctx, String json) {
+        ctx.contentType("application/json");
+        ctx.result(json == null ? "{}" : json);
     }
 }

--- a/src/main/java/com/pwn_burp/api/handlers/ScopeHandler.java
+++ b/src/main/java/com/pwn_burp/api/handlers/ScopeHandler.java
@@ -36,7 +36,15 @@ public class ScopeHandler {
     )
     private void getScope(Context ctx) {
         String urlParam = ctx.pathParam("url") != null ? ctx.pathParam("url") : "";
-        String plainURL = new String(Base64.getDecoder().decode(urlParam));
+        String plainURL;
+        try {
+            plainURL = new String(Base64.getDecoder().decode(urlParam));
+        } catch (IllegalArgumentException e) {
+            ctx.status(400);
+            ctx.json(pwnService.apiError("url", "Invalid Base64-encoded URL"));
+            return;
+        }
+
         try {
             URL url = URI.create(plainURL).toURL();
             ctx.status(200);
@@ -84,7 +92,15 @@ public class ScopeHandler {
     )
     private void deleteScope(Context ctx) {
         String urlParam = ctx.pathParam("url") != null ? ctx.pathParam("url") : "";
-        String plainURL = new String(Base64.getDecoder().decode(urlParam));
+        String plainURL;
+        try {
+            plainURL = new String(Base64.getDecoder().decode(urlParam));
+        } catch (IllegalArgumentException e) {
+            ctx.status(400);
+            ctx.json(pwnService.apiError("url", "Invalid Base64-encoded URL"));
+            return;
+        }
+
         try {
             URL url = URI.create(plainURL).toURL(); // Fix deprecated URL constructor (line 93)
             pwnService.excludeFromScope(url);

--- a/src/main/java/com/pwn_burp/api/handlers/SiteMapHandler.java
+++ b/src/main/java/com/pwn_burp/api/handlers/SiteMapHandler.java
@@ -83,7 +83,7 @@ public class SiteMapHandler {
         String highlight = ctx.queryParamAsClass("highlight", String.class).getOrDefault("NONE");
 
         ctx.status(200);
-        ctx.json(pwnService.getSiteMap(urlPrefix, limit, offset, highlight));
+        respondWithJsonString(ctx, pwnService.getSiteMap(urlPrefix, limit, offset, highlight));
     }
 
     @OpenApi(
@@ -140,13 +140,22 @@ public class SiteMapHandler {
         }
     )
     private void getSiteMapByUrl(Context ctx) {
-        String urlPrefix = new String(Base64.getDecoder().decode(ctx.pathParam("url") != null ? ctx.pathParam("url") : ""));
+        String encodedUrl = ctx.pathParam("url") != null ? ctx.pathParam("url") : "";
+        String urlPrefix;
+        try {
+            urlPrefix = new String(Base64.getDecoder().decode(encodedUrl));
+        } catch (IllegalArgumentException e) {
+            ctx.status(400);
+            ctx.json(pwnService.apiError("url", "Invalid Base64-encoded URL prefix"));
+            return;
+        }
+
         int limit  = ctx.queryParamAsClass("limit", Integer.class).getOrDefault(200);
         int offset = ctx.queryParamAsClass("offset", Integer.class).getOrDefault(0);
         String highlight = ctx.queryParamAsClass("highlight", String.class).getOrDefault("NONE");
 
         ctx.status(200);
-        ctx.json(pwnService.getSiteMap(urlPrefix, limit, offset, highlight));
+        respondWithJsonString(ctx, pwnService.getSiteMap(urlPrefix, limit, offset, highlight));
     }
 
     @OpenApi(
@@ -231,5 +240,10 @@ public class SiteMapHandler {
         } catch (Exception e) {
             ctx.status(400).json(pwnService.apiError("error", e.getMessage()));
         }
+    }
+
+    private void respondWithJsonString(Context ctx, String json) {
+        ctx.contentType("application/json");
+        ctx.result(json == null ? "{}" : json);
     }
 }

--- a/src/main/java/com/pwn_burp/burp/ProxyService.java
+++ b/src/main/java/com/pwn_burp/burp/ProxyService.java
@@ -105,9 +105,9 @@ public class ProxyService {
                     obj.addProperty("response", responseBase64);
 
                     // Annotations
-                    highlight = (item.annotations() != null && item.annotations().highlightColor() != null)
+                    String itemHighlight = (item.annotations() != null && item.annotations().highlightColor() != null)
                             ? item.annotations().highlightColor().toString() : "";
-                    obj.addProperty("highlight", highlight);
+                    obj.addProperty("highlight", itemHighlight);
 
                     String comment = (item.annotations() != null && item.annotations().notes() != null)
                             ? item.annotations().notes() : "";
@@ -206,9 +206,9 @@ public class ProxyService {
                     int webSocketId = item.webSocketId();
                     obj.addProperty("web_socket_id", webSocketId >= 0 ? webSocketId : -1);
 
-                    highlight = (item.annotations() != null && item.annotations().highlightColor() != null)
+                    String itemHighlight = (item.annotations() != null && item.annotations().highlightColor() != null)
                             ? item.annotations().highlightColor().toString() : "";
-                    obj.addProperty("highlight", highlight);
+                    obj.addProperty("highlight", itemHighlight);
 
                     String comment = (item.annotations() != null && item.annotations().notes() != null)
                             ? item.annotations().notes() : "";

--- a/src/main/java/com/pwn_burp/config/ConfigManager.java
+++ b/src/main/java/com/pwn_burp/config/ConfigManager.java
@@ -2,6 +2,7 @@ package com.pwn_burp.config;
 
 import burp.api.montoya.logging.Logging;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 public class ConfigManager {
@@ -18,12 +19,16 @@ public class ConfigManager {
 
     public void loadConfig() {
         Properties props = new Properties();
-        try {
-            props.load(ConfigManager.class.getResourceAsStream("/config.properties"));
-            serverAddress = props.getProperty("server.address", serverAddress);
-            serverPort = Integer.parseInt(props.getProperty("server.port", String.valueOf(serverPort)));
-            proxyAddress = props.getProperty("proxy.address", proxyAddress);
-            proxyPort = Integer.parseInt(props.getProperty("proxy.port", String.valueOf(proxyPort)));
+        try (InputStream stream = ConfigManager.class.getResourceAsStream("/config.properties")) {
+            if (stream != null) {
+                props.load(stream);
+                serverAddress = props.getProperty("server.address", serverAddress);
+                serverPort = Integer.parseInt(props.getProperty("server.port", String.valueOf(serverPort)));
+                proxyAddress = props.getProperty("proxy.address", proxyAddress);
+                proxyPort = Integer.parseInt(props.getProperty("proxy.port", String.valueOf(proxyPort)));
+            } else {
+                logging.logToError("config.properties not found on classpath; using defaults");
+            }
         } catch (IOException | NumberFormatException e) {
             logging.logToError("Failed to load config: " + e.getMessage());
         }
@@ -55,7 +60,7 @@ public class ConfigManager {
     }
 
     public String getProxyAddress() {
-        return serverAddress;
+        return proxyAddress;
     }
 
     public int getProxyPort() {


### PR DESCRIPTION
## Summary
This PR fixes several obvious runtime and operational bugs found during a full source review of `pwn_burp`.

### Fixes included
- Fix `ConfigManager#getProxyAddress()` returning the wrong value (`serverAddress` → `proxyAddress`).
- Guard config loading when `/config.properties` is missing from classpath (avoid NPE and keep sane defaults).
- Fix proxy/websocket highlight filtering bug where request filter state was overwritten while iterating history.
- Fix JSON response rendering for stringified JSON payloads in handlers (`ctx.json(String)` was double-encoding payloads as JSON strings).
  - Updated affected endpoints to return raw JSON with `Content-Type: application/json`.
- Add Base64 decode validation for URL path params in multiple handlers, returning `400` instead of bubbling runtime decode errors.
- Harden `install.sh`:
  - pin Java runtime to JDK 21 for Gradle
  - make script deterministic with `set -euo pipefail`
  - run Gradle as invoking user when script is launched via `sudo`, preventing root-owned artifacts that break later local builds
  - ensure daemon stop and build run from repo root
- Add `gradle.properties` with `org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64` to keep builds stable across system Java upgrades.

## Validation
- `./gradlew clean build shadowJar` ✅
- `sudo ./install.sh` ✅
- Verified build artifacts remain user-writable after sudo install flow ✅
